### PR TITLE
Fix failing tests

### DIFF
--- a/src/algorithms/search/js/Binary Search/binary-search-implementation.js
+++ b/src/algorithms/search/js/Binary Search/binary-search-implementation.js
@@ -7,9 +7,9 @@ class BinarySearch {
 
     // if a comparator is passed in, use it to compare the target and the middle element
     if (comparator !== undefined) {
-      while (comparator(sortedArray[mid], target) !== 0 && start <= end) {
+      while (comparator(target, sortedArray[mid]) !== 0 && start <= end) {
         // if the target is less than the middle element, then the target is in the left half of the array
-        if (comparator(sortedArray[mid], target) === -1) {
+        if (comparator(target, sortedArray[mid]) === -1) {
           end = mid - 1;
         }
         // if the target is greater than the middle element, then the target is in the right half of the array
@@ -20,7 +20,7 @@ class BinarySearch {
       }
 
       // if the target is not found, return -1
-      return comparator(sortedArray[mid], target) === 0 ? mid : -1;
+      return comparator(target, sortedArray[mid]) === 0 ? mid : -1;
     }
 
     while (sortedArray[mid] !== target && start <= end) {

--- a/src/data-structures/linear/linked-lists/js/LinkedList.js
+++ b/src/data-structures/linear/linked-lists/js/LinkedList.js
@@ -47,7 +47,7 @@ class LinkedList {
   //Print List (value) O(n)
   getByIndex(index) {
     // if the index is out of bounds, return null
-    if (index < 0 || index >= this.length) return null;
+    if (index < 0 || index >= this.size) return null;
     let current = this.head;
     for (let i = 0; i < index; i++) {
       current = current.next;
@@ -69,7 +69,7 @@ class LinkedList {
 
   //inserts a new element at a given index
   insert(value, index) {
-    if (index < 0 || index > this.length) {
+    if (index < 0 || index > this.size) {
       return -1;
     } else if (index === 0) {
       this.prepend(value);
@@ -109,7 +109,7 @@ class LinkedList {
         count++;
       }
       current.next = current.next.next;
-      this.length--;
+      this.size--;
     }
   }
 
@@ -149,4 +149,4 @@ LinkedList.fromValues = (...values) => {
   return myLinkedList;
 };
 
-export default LinkedList;
+module.exports = LinkedList;


### PR DESCRIPTION
The comparator in binary search returns an inverted expected result. Switching argument position of target and array resolves this

In linked list length is not a known field, replace that with size instead
